### PR TITLE
Fix “No music found” flash while loading music list

### DIFF
--- a/app/src/main/java/com/tuno/player/screens/musicList.kt
+++ b/app/src/main/java/com/tuno/player/screens/musicList.kt
@@ -122,11 +122,7 @@ fun MusicListScreen(
 
     when (uiState) {
         is MusicListUiState.Loading -> {
-            Box(modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Text("Loading music...")
-            }
+            Box(modifier = Modifier.fillMaxSize()) { }
         }
         is MusicListUiState.Empty -> {
             Box(modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Fixes #2 

### Desc:
This PR addresses a brief UI glitch where the “No music found” message would appear momentarily while the music list was being fetched asynchronously.

### Changes:
- Introduced a sealed class `MusicListUiState` with `Loading`, `Empty`, and `Success` states for the music list.
- Replaced `LaunchedEffect` + mutable state with `produceState` to fetch the music list asynchronously.
- Updated `MusicListScreen` to display:
    - **Loading** while fetching
    - **No music found** only if the list is empty after fetch
    - **Music list** once successfully fetched